### PR TITLE
update carto tables to use alias views instead of hardcoded versions

### DIFF
--- a/addon/components/labs-bbl-lookup.js
+++ b/addon/components/labs-bbl-lookup.js
@@ -58,7 +58,7 @@ export default Component.extend({
       const validLot = this.get('validLot');
 
       if (validBlock && !validLot) {
-        const SQL = `SELECT the_geom FROM mappluto_block_centroids WHERE block= ${parseInt(block, 10)} AND borocode = ${code}`;
+        const SQL = `SELECT the_geom FROM dtm_block_centroids WHERE block= ${parseInt(block, 10)} AND borocode = ${code}`;
         carto.SQL(SQL, 'geojson').then((response) => {
           if (response.features[0]) {
             this.set('errorMessage', '');
@@ -71,7 +71,7 @@ export default Component.extend({
           }
         });
       } else {
-        const SQL = `SELECT st_centroid(the_geom) as the_geom, bbl FROM mappluto_18v2 WHERE block= ${parseInt(block, 10)} AND lot = ${parseInt(lot, 10)} AND borocode = ${code}`;
+        const SQL = `SELECT st_centroid(the_geom) as the_geom, bbl FROM mappluto WHERE block= ${parseInt(block, 10)} AND lot = ${parseInt(lot, 10)} AND borocode = ${code}`;
         carto.SQL(SQL, 'geojson').then((response) => {
           if (response.features[0]) {
             this.set('errorMessage', '');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "labs-ember-search",
   "license": "MIT",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "repository": "",
   "scripts": {
     "build": "ember build",


### PR DESCRIPTION
- Closes #17 by pointing to the `dtm_block_centroids` aliased view
- Closes #18 by pointing to the `mappluto` aliased view
- Updates package version