### PR TITLE
Prevents clicking submit when bbl and or lot are invalid

### DIFF
--- a/addon/components/labs-bbl-lookup.js
+++ b/addon/components/labs-bbl-lookup.js
@@ -35,6 +35,8 @@ export default Component.extend({
 
   flyTo: null,
 
+  onSuccess: () => {},
+
   actions: {
     validate() {
       const boro = this.get('boro');

--- a/addon/templates/components/labs-bbl-lookup.hbs
+++ b/addon/templates/components/labs-bbl-lookup.hbs
@@ -40,7 +40,12 @@
     </div>
     {{#if errorMessage}}<p class="lu-red text-center text-small">{{errorMessage}}</p>{{/if}}
 
-    <input type="submit" value={{submitText}} class="button small expanded no-margin {{if (or validBlock validLot) '' 'disabled'}}">
+    <input
+      type="submit"
+      value={{submitText}}
+      class="button small expanded no-margin {{if (or validBlock validLot) '' 'disabled'}}"
+      disabled={{not (or validBlock validLot)}}
+    />
   </form>
 {{/unless}}
 


### PR DESCRIPTION
This change is intended to address https://github.com/NYCPlanning/labs-zola/issues/921

It fixes it by natively disabling the form "submit" button whenever the lot/bbl fields are invalid.

If those fields are invalid, it is possible to hit submit and generate a broken query.
