### PR TITLE
5901 Start with 3.1.3 commit and then updating bbl lookup to use correct carto datasets

### DIFF
--- a/addon/components/labs-bbl-lookup.js
+++ b/addon/components/labs-bbl-lookup.js
@@ -58,7 +58,7 @@ export default Component.extend({
       const validLot = this.get('validLot');
 
       if (validBlock && !validLot) {
-        const SQL = `SELECT the_geom FROM dtm_block_centroids WHERE block= ${parseInt(block, 10)} AND borocode = ${code}`;
+        const SQL = `SELECT the_geom FROM dof_dtm_block_centroids WHERE block= ${parseInt(block, 10)} AND borocode = ${code}`;
         carto.SQL(SQL, 'geojson').then((response) => {
           if (response.features[0]) {
             this.set('errorMessage', '');
@@ -71,7 +71,7 @@ export default Component.extend({
           }
         });
       } else {
-        const SQL = `SELECT st_centroid(the_geom) as the_geom, bbl FROM mappluto WHERE block= ${parseInt(block, 10)} AND lot = ${parseInt(lot, 10)} AND borocode = ${code}`;
+        const SQL = `SELECT st_centroid(the_geom) as the_geom, bbl FROM dcp_mappluto WHERE block= ${parseInt(block, 10)} AND lot = ${parseInt(lot, 10)} AND borocode = ${code}`;
         carto.SQL(SQL, 'geojson').then((response) => {
           if (response.features[0]) {
             this.set('errorMessage', '');


### PR DESCRIPTION
This PR takes [this commit](https://github.com/NYCPlanning/labs-ember-search/commit/d5af263631adc877c0f3727501986b3bf3d7f541), which was the last one done before I bunch of dependency upgrades that our apps don't work with were done, and then updates some carto queries to point to correct datasets. This should allow us to get a working version of this addon into apps like Zola and Streets that use the correct datasets