### PR TITLE
5901 Fix block centroid query to send borocode as a string

### DIFF
--- a/addon/components/labs-bbl-lookup.js
+++ b/addon/components/labs-bbl-lookup.js
@@ -58,7 +58,7 @@ export default Component.extend({
       const validLot = this.get('validLot');
 
       if (validBlock && !validLot) {
-        const SQL = `SELECT the_geom FROM dof_dtm_block_centroids WHERE block= ${parseInt(block, 10)} AND borocode = ${code}`;
+        const SQL = `SELECT the_geom FROM dof_dtm_block_centroids WHERE block= ${parseInt(block, 10)} AND borocode = '${code}'`;
         carto.SQL(SQL, 'geojson').then((response) => {
           if (response.features[0]) {
             this.set('errorMessage', '');


### PR DESCRIPTION
This PR fixes a bug due to passing the borocode for block lookup as an integer when it must be a string. Note that the other query in that file for tax lots _does_ expect an integer because the data schema of that dataset is different.