### PR TITLE
3799 – Change borocode to boro in BBL lookup SQL query strings

### DIFF
--- a/addon/components/labs-bbl-lookup.js
+++ b/addon/components/labs-bbl-lookup.js
@@ -58,7 +58,7 @@ export default Component.extend({
       const validLot = this.get('validLot');
 
       if (validBlock && !validLot) {
-        const SQL = `SELECT the_geom FROM dof_dtm_block_centroids WHERE block= ${parseInt(block, 10)} AND borocode = '${code}'`;
+        const SQL = `SELECT the_geom FROM dof_dtm_block_centroids WHERE block= ${parseInt(block, 10)} AND boro = '${code}'`;
         carto.SQL(SQL, 'geojson').then((response) => {
           if (response.features[0]) {
             this.set('errorMessage', '');
@@ -71,7 +71,7 @@ export default Component.extend({
           }
         });
       } else {
-        const SQL = `SELECT st_centroid(the_geom) as the_geom, bbl FROM dcp_mappluto WHERE block= ${parseInt(block, 10)} AND lot = ${parseInt(lot, 10)} AND borocode = ${code}`;
+        const SQL = `SELECT st_centroid(the_geom) as the_geom, bbl FROM dcp_mappluto WHERE block= ${parseInt(block, 10)} AND lot = ${parseInt(lot, 10)} AND boro = ${code}`;
         carto.SQL(SQL, 'geojson').then((response) => {
           if (response.features[0]) {
             this.set('errorMessage', '');


### PR DESCRIPTION
The block lookup feature was not working in ZoLa as a SQL error would occur when attempt to fetch the data. The issue was that the SQL queries are referencing out-of-date variable names, chiefly borocode instead of boro. This has been updated to match the Carto dataset.

I have not been able to test this fix on my machine. I've attempted to use [yarn link](https://piyushswain.github.io/usage-of-yarn-link/) to use a local instance of this package in ZoLa but that caused an error at build time (pic related). Ideas on how to test this fix locally would be appreciated!

![Screen Shot 2022-08-30 at 12 27 39 PM](https://user-images.githubusercontent.com/43344288/187490473-9a85fae1-e050-493b-9a60-a4c42f729f51.png)
