### PR TITLE
3799 – Change SQL query to match Carto column name in dof_dtm_block_centroids

### DIFF
--- a/addon/components/labs-bbl-lookup.js
+++ b/addon/components/labs-bbl-lookup.js
@@ -58,7 +58,7 @@ export default Component.extend({
       const validLot = this.get('validLot');
 
       if (validBlock && !validLot) {
-        const SQL = `SELECT the_geom FROM dof_dtm_block_centroids WHERE block= ${parseInt(block, 10)} AND borocode = '${code}'`;
+        const SQL = `SELECT the_geom FROM dof_dtm_block_centroids WHERE block= ${parseInt(block, 10)} AND boro = '${code}'`;
         carto.SQL(SQL, 'geojson').then((response) => {
           if (response.features[0]) {
             this.set('errorMessage', '');


### PR DESCRIPTION
Resolves AB[#3799](https://dev.azure.com/NYCPlanning/ITD/_sprints/taskboard/Open%20Source%20Engineering/ITD/2022/Q3/Sprint%20R?workitem=3799).

The previous attempt at a fix changed borocode to boro in all BBL lookup SQL queries. The issue was that on Carto dcp_mappluto still uses borocode as it's column name, while dof_dtm_block_centroids uses boro. SQL queries have been updated accordingly.

Before:
<img width="877" alt="Screen Shot 2022-09-01 at 1 29 01 PM" src="https://user-images.githubusercontent.com/43344288/187977416-93984415-9598-409f-a56e-e06c2a9e4f31.png">

After:
<img width="874" alt="Screen Shot 2022-09-01 at 1 28 35 PM" src="https://user-images.githubusercontent.com/43344288/187977439-7e0e02d4-9502-45fa-8112-06674c8a2769.png">
